### PR TITLE
feat: add initial file to create window with transparent colour

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ int main() {
         return -1;
     }
     SDL_Texture *mainTexture{SDL_CreateTexture(
-        mainRenderer, SDL_PIXELFORMAT_ARGB4444, SDL_TEXTUREACCESS_STREAMING,
+        mainRenderer, SDL_PIXELFORMAT_ARGB4444, SDL_TEXTUREACCESS_STATIC,
         SCREEN_WIDTH, SCREEN_HEIGHT)};
     if (mainTexture == nullptr) {
         std::cerr << "SDL_CreateTexture Error: " << SDL_GetError() << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,8 @@
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_blendmode.h>
 #include <SDL3/SDL_events.h>
+#include <SDL3/SDL_log.h>
 #include <SDL3/SDL_render.h>
-#include <iostream>
 
 const int SCREEN_WIDTH = 1000;
 const int SCREEN_HEIGHT = 800;
@@ -14,20 +14,22 @@ const int COLOR_ALPHA = 128;
 int main() {
     bool init{SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS)};
     if (!init) {
-        std::cerr << "SDL_Init Error: " << SDL_GetError() << std::endl;
+        SDL_LogCritical(SDL_LOG_CATEGORY_ERROR, "SDL_Init Error: %s\n",
+                        SDL_GetError());
         return -1;
     }
     SDL_Window *mainWindow{
         SDL_CreateWindow("SDL3 Window", SCREEN_WIDTH, SCREEN_HEIGHT,
                          SDL_WINDOW_RESIZABLE | SDL_WINDOW_TRANSPARENT)};
     if (mainWindow == nullptr) {
-        std::cerr << "SDL_CreateWindow Error: " << SDL_GetError() << std::endl;
+        SDL_LogCritical(SDL_LOG_CATEGORY_ERROR, "SDL_CreateWindow Error: %s\n",
+                        SDL_GetError());
         return -1;
     }
     SDL_Renderer *mainRenderer{SDL_CreateRenderer(mainWindow, NULL)};
     if (mainRenderer == nullptr) {
-        std::cerr << "SDL_CreateRenderer Error: " << SDL_GetError()
-                  << std::endl;
+        SDL_LogCritical(SDL_LOG_CATEGORY_ERROR,
+                        "SDL_CreateRenderer Error: %s\n", SDL_GetError());
         SDL_DestroyWindow(mainWindow);
         SDL_Quit();
         return -1;
@@ -37,7 +39,8 @@ int main() {
         mainRenderer, SDL_PIXELFORMAT_ARGB4444, SDL_TEXTUREACCESS_STATIC,
         SCREEN_WIDTH, SCREEN_HEIGHT)};
     if (mainTexture == nullptr) {
-        std::cerr << "SDL_CreateTexture Error: " << SDL_GetError() << std::endl;
+        SDL_LogCritical(SDL_LOG_CATEGORY_ERROR,
+                        "SDL_CreateTexture Error: %s\n", SDL_GetError());
         SDL_DestroyRenderer(mainRenderer);
         SDL_DestroyWindow(mainWindow);
         SDL_Quit();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,7 +52,8 @@ int main() {
                 quit = true;
             }
         }
-        SDL_SetRenderDrawColor(mainRenderer, COLOR_RED, COLOR_GREEN, COLOR_BLUE, COLOR_ALPHA);
+        SDL_SetRenderDrawColor(mainRenderer, COLOR_RED, COLOR_GREEN, COLOR_BLUE,
+                               COLOR_ALPHA);
         SDL_RenderClear(mainRenderer);
         SDL_RenderPresent(mainRenderer);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,59 @@
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_blendmode.h>
+#include <SDL3/SDL_events.h>
+#include <SDL3/SDL_render.h>
+#include <iostream>
+
+const int SCREEN_WIDTH = 1000;
+const int SCREEN_HEIGHT = 800;
+
+int main() {
+    bool init{SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS)};
+    if (!init) {
+        std::cerr << "SDL_Init Error: " << SDL_GetError() << std::endl;
+        return -1;
+    }
+    SDL_Window *mainWindow{
+        SDL_CreateWindow("SDL3 Window", SCREEN_WIDTH, SCREEN_HEIGHT,
+                         SDL_WINDOW_RESIZABLE | SDL_WINDOW_TRANSPARENT)};
+    if (mainWindow == nullptr) {
+        std::cerr << "SDL_CreateWindow Error: " << SDL_GetError() << std::endl;
+        return -1;
+    }
+    SDL_Renderer *mainRenderer{SDL_CreateRenderer(mainWindow, 0)};
+    if (mainRenderer == nullptr) {
+        std::cerr << "SDL_CreateRenderer Error: " << SDL_GetError()
+                  << std::endl;
+        SDL_DestroyWindow(mainWindow);
+        SDL_Quit();
+        return -1;
+    }
+    SDL_Texture *mainTexture{SDL_CreateTexture(
+        mainRenderer, SDL_PIXELFORMAT_ARGB4444, SDL_TEXTUREACCESS_STREAMING,
+        SCREEN_WIDTH, SCREEN_HEIGHT)};
+    if (mainTexture == nullptr) {
+        std::cerr << "SDL_CreateTexture Error: " << SDL_GetError() << std::endl;
+        SDL_DestroyRenderer(mainRenderer);
+        SDL_DestroyWindow(mainWindow);
+        SDL_Quit();
+        return -1;
+    }
+    SDL_Event event;
+    bool quit{false};
+    while (!quit) {
+        while (SDL_PollEvent(&event)) {
+            if (event.type == SDL_EVENT_QUIT ||
+                event.type == SDL_EVENT_TERMINATING) {
+                quit = true;
+            }
+        }
+        SDL_SetRenderDrawColor(mainRenderer, 255, 0, 0, 128);
+        SDL_RenderClear(mainRenderer);
+        SDL_RenderPresent(mainRenderer);
+    }
+    SDL_DestroyTexture(mainTexture);
+    SDL_DestroyRenderer(mainRenderer);
+    SDL_DestroyWindow(mainWindow);
+    SDL_Quit();
+    return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ int main() {
         std::cerr << "SDL_CreateWindow Error: " << SDL_GetError() << std::endl;
         return -1;
     }
-    SDL_Renderer *mainRenderer{SDL_CreateRenderer(mainWindow, 0)};
+    SDL_Renderer *mainRenderer{SDL_CreateRenderer(mainWindow, NULL)};
     if (mainRenderer == nullptr) {
         std::cerr << "SDL_CreateRenderer Error: " << SDL_GetError()
                   << std::endl;
@@ -32,6 +32,7 @@ int main() {
         SDL_Quit();
         return -1;
     }
+    /* Currently unused
     SDL_Texture *mainTexture{SDL_CreateTexture(
         mainRenderer, SDL_PIXELFORMAT_ARGB4444, SDL_TEXTUREACCESS_STATIC,
         SCREEN_WIDTH, SCREEN_HEIGHT)};
@@ -41,7 +42,7 @@ int main() {
         SDL_DestroyWindow(mainWindow);
         SDL_Quit();
         return -1;
-    }
+    } */
     SDL_Event event;
     bool quit{false};
     while (!quit) {
@@ -55,7 +56,7 @@ int main() {
         SDL_RenderClear(mainRenderer);
         SDL_RenderPresent(mainRenderer);
     }
-    SDL_DestroyTexture(mainTexture);
+    // SDL_DestroyTexture(mainTexture);
     SDL_DestroyRenderer(mainRenderer);
     SDL_DestroyWindow(mainWindow);
     SDL_Quit();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,10 @@
 
 const int SCREEN_WIDTH = 1000;
 const int SCREEN_HEIGHT = 800;
+const int COLOR_RED = 255;
+const int COLOR_GREEN = 0;
+const int COLOR_BLUE = 0;
+const int COLOR_ALPHA = 128;
 
 int main() {
     bool init{SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS)};
@@ -47,7 +51,7 @@ int main() {
                 quit = true;
             }
         }
-        SDL_SetRenderDrawColor(mainRenderer, 255, 0, 0, 128);
+        SDL_SetRenderDrawColor(mainRenderer, COLOR_RED, COLOR_GREEN, COLOR_BLUE, COLOR_ALPHA);
         SDL_RenderClear(mainRenderer);
         SDL_RenderPresent(mainRenderer);
     }


### PR DESCRIPTION
This is a basic initial setup that starts the event and video subsystems, so that we can show a window (currently a single colour), and can handle when the application is required to quit.