### PR TITLE
refactor: convert main file to use callbacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(GameEngine
     PRIVATE
     src/main.cpp
 )
+target_compile_definitions(GameEngine PUBLIC SDL_MAIN_USE_CALLBACKS)
 target_link_libraries(GameEngine PRIVATE SDL3::SDL3)
 set_target_properties(GameEngine
     PROPERTIES

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,5 @@
 #include <SDL3/SDL.h>
-#include <SDL3/SDL_blendmode.h>
-#include <SDL3/SDL_events.h>
-#include <SDL3/SDL_log.h>
-#include <SDL3/SDL_render.h>
+#include <SDL3/SDL_main.h>
 
 const int SCREEN_WIDTH = 1000;
 const int SCREEN_HEIGHT = 800;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,27 +22,27 @@ SDL_AppResult SDL_Failure(const char *fmt) {
     return SDL_APP_FAILURE;
 }
 
-// Initialises subsystems and initialises appState to be used by all other main functions.
+// Initialises subsystems and initialises appState to be used by all other main
+// functions.
 SDL_AppResult SDL_AppInit(void **appState, int argc, char *argv[]) {
     AppState *state{new AppState{
-        .mainWindow = NULL,
+        .mainWindow = nullptr,
         .mainRenderer =
-            NULL}}; // This only is useful this way if we are initialising
-                    // subsystems using pointers, which isn't very common. We
-                    // can instead initialise the state after all subsystems are
-                    // initialised, but this depends on which subsystems we are
-                    // initialising.
+            nullptr}}; // This only is useful this way if we are initialising
+                       // subsystems using pointers, which isn't very common. We
+                       // can instead initialise the state after all subsystems
+                       // are initialised, but this depends on which subsystems
+                       // we are initialising.
     SDL_SetAppMetadata("GameEngine", "0.0.1",
                        "org.acm.pesuecc.aiep.game-engine");
-    bool init{SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS)};
-    if (!init) {
+    if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS)) {
         return SDL_Failure("Error initialising SDL3");
     }
-    init = SDL_CreateWindowAndRenderer(
+    bool initWindowRenderer{SDL_CreateWindowAndRenderer(
         "GameEngine", SCREEN_WIDTH, SCREEN_HEIGHT,
         SDL_WINDOW_RESIZABLE | SDL_WINDOW_TRANSPARENT, &(state->mainWindow),
-        &(state->mainRenderer));
-    if (!init) {
+        &(state->mainRenderer))};
+    if (!initWindowRenderer) {
         return SDL_Failure("Error creating Window and Renderer");
     }
     *appState = state;


### PR DESCRIPTION
*   **CMakeLists.txt:** Added `SDL_MAIN_USE_CALLBACKS` compile definition. This is required to use the SDL3's `SDL_main` entry point.
*   **src/main.cpp:**
    *   Replaced the traditional `main` function with the SDL3's `SDL_AppInit`, `SDL_AppEvent`, `SDL_AppIterate`, and `SDL_AppQuit` functions.
    *   Introduced an `AppState` struct to encapsulate the application's state, including the main window, renderer, and application result.
    *   Implemented basic event handling for `SDL_EVENT_QUIT` and `SDL_EVENT_TERMINATING` events.
    *   Moved the rendering logic into the `SDL_AppIterate` function.
    *   Added error handling using `SDL_Failure` helper function.
    *   Added metadata to the application using `SDL_SetAppMetadata`.
*   This PR introduces a breaking change by removing the traditional `main` function.
*   The event handling is currently basic and can be extended in future PRs to support more complex interactions.
*   The `AppState` struct can be further expanded to include other application-specific data.
