### PR TITLE
fix: add warnings, with C++17 enforced to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,12 @@ target_sources(GameEngine
     PRIVATE
     src/main.cpp
 )
+target_compile_features(GameEngine PUBLIC cxx_std_17)
 target_compile_definitions(GameEngine PUBLIC SDL_MAIN_USE_CALLBACKS)
+target_compile_options(GameEngine PUBLIC
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Wno-unused-parameter>
+)
 target_link_libraries(GameEngine PRIVATE SDL3::SDL3)
 set_target_properties(GameEngine
     PROPERTIES


### PR DESCRIPTION
### Which issue(s) does this PR address?
This PR addresses the lack of any standard enforcement in the compilation and adds warnings.

### Why do we need this PR?
This PR will help foster a better programming attitude.

### What logical changes are present in this PR?
Added warnings to CMakeLists.txt

### How did you test the changes in this PR?
```console
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/delta/Programming/C/CXX/game-engine-aiep
[ 50%] Building CXX object CMakeFiles/GameEngine.dir/src/main.cpp.o
[100%] Linking CXX executable bin/GameEngine
[100%] Built target GameEngine
```

### Are there any breaking changes in this PR?
There are no breaking changes in this PR.

### Is there some additional work to be done later that is NOT covered in this PR?
There is always scope for improvement in the CMake config.
