### PR TITLE
feat: add vendored dependencies management with ImGui integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,8 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 /bin*
-
+include/vendored/*
+!include/vendored/vendored.cmake
 ### CMake Patch ###
 CMakeUserPresets.json
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,20 +6,36 @@ project(GameEngine
 )
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-find_package(SDL3 REQUIRED CONFIG REQUIRED COMPONENTS SDL3-shared)
 
 add_executable(GameEngine)
 target_sources(GameEngine
     PRIVATE
     src/main.cpp
 )
+
+include(include/vendored/vendored.cmake)
+
 target_compile_features(GameEngine PUBLIC cxx_std_17)
-target_compile_definitions(GameEngine PUBLIC SDL_MAIN_USE_CALLBACKS)
-target_compile_options(GameEngine PUBLIC
-  $<$<CXX_COMPILER_ID:MSVC>:/W4>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Wno-unused-parameter>
+target_compile_definitions(GameEngine
+                           PUBLIC SDL_MAIN_USE_CALLBACKS
+                           PUBLIC IMGUI_ENABLE_DOCKING=
+                           PUBLIC IMGUI_DEFINE_MATH_OPERATORS=
+                           PUBLIC IMGUI_IMPL_API=
 )
-target_link_libraries(GameEngine PRIVATE SDL3::SDL3)
+target_compile_options(GameEngine
+    PUBLIC
+    $<$<CXX_COMPILER_ID:MSVC>:/W4>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Wno-unused-parameter>
+)
+
+add_dependencies(GameEngine imgui_sdl3)
+target_link_libraries(GameEngine
+    PRIVATE
+    SDL3::SDL3
+    SDL3_ttf::SDL3_ttf
+    imgui_sdl3
+)
+
 set_target_properties(GameEngine
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,5 +38,4 @@ target_link_libraries(GameEngine
 set_target_properties(GameEngine
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16...4.0)
+cmake_minimum_required(VERSION 3.28...4.0)
 project(GameEngine
     VERSION 0.0.1
     DESCRIPTION "2D Game Engine built during AIEP 2025"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ target_compile_options(GameEngine
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Wno-unused-parameter>
 )
 
-add_dependencies(GameEngine imgui_sdl3)
 target_link_libraries(GameEngine
     PRIVATE
     SDL3::SDL3

--- a/include/vendored/vendored.cmake
+++ b/include/vendored/vendored.cmake
@@ -23,6 +23,7 @@ FetchContent_MakeAvailable(SDL3 SDL3_ttf)
 FetchContent_Populate(imgui
   URL https://github.com/ocornut/imgui/archive/master.zip
   SOURCE_DIR ${CMAKE_SOURCE_DIR}/include/vendored/imgui
+  BINARY_DIR ${CMAKE_SOURCE_DIR}/_deps/imgui-build
 )
 add_library(imgui_sdl3
     STATIC
@@ -39,3 +40,7 @@ target_include_directories(imgui_sdl3 PUBLIC
     ${CMAKE_SOURCE_DIR}/include/vendored/imgui/backends
 )
 target_link_libraries(imgui_sdl3 PRIVATE SDL3::SDL3)
+set_target_properties(imgui_sdl3
+    PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/_deps/imgui-build
+)

--- a/include/vendored/vendored.cmake
+++ b/include/vendored/vendored.cmake
@@ -38,3 +38,4 @@ target_include_directories(imgui_sdl3 PUBLIC
     ${CMAKE_SOURCE_DIR}/include/vendored/imgui
     ${CMAKE_SOURCE_DIR}/include/vendored/imgui/backends
 )
+target_link_libraries(imgui_sdl3 PRIVATE SDL3::SDL3)

--- a/include/vendored/vendored.cmake
+++ b/include/vendored/vendored.cmake
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.28...4.0)
+include(FetchContent)
+
+set(BUILD_SHARED_LIBS OFF)
+set(SDL_SHARED OFF)
+set(SDL_STATIC ON)
+
+FetchContent_Declare(
+    SDL3
+    GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
+    GIT_TAG release-3.2.10
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/include/vendored/SDL3
+    EXCLUDE_FROM_ALL
+)
+FetchContent_Declare(
+    SDL3_ttf
+    GIT_REPOSITORY https://github.com/libsdl-org/SDL_ttf.git
+    GIT_TAG release-3.2.2
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/include/vendored/SDL3_ttf
+    EXCLUDE_FROM_ALL
+)
+FetchContent_MakeAvailable(SDL3 SDL3_ttf)
+FetchContent_Populate(imgui
+  URL https://github.com/ocornut/imgui/archive/master.zip
+  SOURCE_DIR ${CMAKE_SOURCE_DIR}/include/vendored/imgui
+)
+add_library(imgui_sdl3
+    STATIC
+    ${CMAKE_SOURCE_DIR}/include/vendored/imgui/imgui.cpp
+    ${CMAKE_SOURCE_DIR}/include/vendored/imgui/imgui_demo.cpp
+    ${CMAKE_SOURCE_DIR}/include/vendored/imgui/imgui_draw.cpp
+    ${CMAKE_SOURCE_DIR}/include/vendored/imgui/imgui_tables.cpp
+    ${CMAKE_SOURCE_DIR}/include/vendored/imgui/imgui_widgets.cpp
+    ${CMAKE_SOURCE_DIR}/include/vendored/imgui/backends/imgui_impl_sdl3.cpp
+    ${CMAKE_SOURCE_DIR}/include/vendored/imgui/backends/imgui_impl_sdlrenderer3.cpp
+)
+target_include_directories(imgui_sdl3 PUBLIC
+    ${CMAKE_SOURCE_DIR}/include/vendored/imgui
+    ${CMAKE_SOURCE_DIR}/include/vendored/imgui/backends
+)


### PR DESCRIPTION
### Which issue(s) does this PR address?
Needing to install libraries system-wide along with mismatched library versions on different dev's computers.

### Why do we need this PR?
We need to have vendored libraries.

### What logical changes are present in this PR?
This PR now uses static libraries along with pulling the libraries from the internet.

### How did you test the changes in this PR?
```console
cmake .
cmake --build . --target GameEngine
```

### Are there any breaking changes in this PR?
The CMake minimum version was bumped, along with adding the dependencies on SDL3_ttf and ImGui.

### Is there some additional work to be done later that is NOT covered in this PR?
The other dependencies which will be added over time are not present.
