### PR TITLE
fix: ignore build and zed editor config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,8 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
-/bin*
+/[Bb]in*
+/[Bb]uild*
 include/vendored/*
 !include/vendored/vendored.cmake
 ### CMake Patch ###
@@ -66,6 +67,9 @@ CMakeUserPresets.json
 
 # Built Visual Studio Code Extensions
 *.vsix
+
+### Zed ###
+.zed/
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files


### PR DESCRIPTION
### Which issue(s) does this PR address?
The README suggests creating a build folder which would not be ignored by git.

### Why do we need this PR?
When building, git would mark the build folder as untracked, when it should be ignored.

### What logical changes are present in this PR?
Adds the build folder and the zed editor config as ignored by git.

### How did you test the changes in this PR?
After building in this branch,
```console
On branch fix/gitignore
nothing to commit, working tree clean
```

### Are there any breaking changes in this PR?
The build folder is now ignored by git.

### Is there some additional work to be done later that is NOT covered in this PR?
No.